### PR TITLE
Use popup for environment instead of message_dialog

### DIFF
--- a/utils/environment.py
+++ b/utils/environment.py
@@ -90,4 +90,6 @@ class BoxyEnvironmentCommand(sublime_plugin.ApplicationCommand):
         def copy_and_hide(msg):
             sublime.set_clipboard(msg)
             view.hide_popup()
-        view.show_popup((msg.replace('\n', '<br>') + '<br><a href="' + msg + '">Copy</a>'), on_navigate=copy_and_hide)
+        view.show_popup(msg.replace('\n', '<br>') +
+                        '<br><a href="' + msg + '">Copy</a>',
+                        on_navigate=copy_and_hide)

--- a/utils/environment.py
+++ b/utils/environment.py
@@ -86,7 +86,8 @@ class BoxyEnvironmentCommand(sublime_plugin.ApplicationCommand):
             ''' % info
         )
 
-        sublime.message_dialog(
-            msg + '\nInfo has been copied to the clipboard.'
-        )
-        sublime.set_clipboard(msg)
+        view = sublime.active_window().active_view()
+        def copy_and_hide(msg):
+            sublime.set_clipboard(msg)
+            view.hide_popup()
+        view.show_popup((msg.replace('\n', '<br>') + '<br><a href="' + msg + '">Copy</a>'), on_navigate=copy_and_hide)


### PR DESCRIPTION
#### Description
Use a nice html popup for the environment command, instead of the message dialog, hum, *ugly* :confused: popup.

#### Motivation and Context
I guess it ruins the theme, this popup... :D

#### How Has This Been Tested?
It's really simple, I just ran the command, with a file open or not, it's working.

#### Screenshots (if appropriate):

![screenshot](https://cloud.githubusercontent.com/assets/15224242/20637080/3ed74b7e-b3cf-11e6-8a54-b3dde306f219.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) - i haven't submited any issue for this, I think it doesn't worth it.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.


BTW, how do you manage to reload the plugin in the `utils` folders? I tried to reload the `BT.py`, `__init__.py` and then `environment.py`, but I couldn't get to it. I had to restart ST :smile:. Fortunately, it was really small changes.

Thank you again, and have a nice day!

Matt
